### PR TITLE
Fixing PIL import

### DIFF
--- a/processor/resize.py
+++ b/processor/resize.py
@@ -1,6 +1,6 @@
 import logging
 
-import PIL
+from PIL import Image
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +10,7 @@ THUMBNAIL_RATIO = float(THUMBNAIL_WIDTH) / float(THUMBNAIL_HEIGHT)
 
 
 def resize(image_path, resized_path):
-    image = PIL.Image.open(image_path)
+    image = Image.open(image_path)
     x, y = image.size
     if (float(x) / float(y)) >= THUMBNAIL_RATIO:
         delta = x - (THUMBNAIL_RATIO * float(y))

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -1,8 +1,6 @@
 import unittest
 
 import mock
-import PIL
-assert PIL  # workaround for pyflakes unused import warning
 
 from processor import resize
 
@@ -10,7 +8,7 @@ from processor import resize
 class ResizeTest(unittest.TestCase):
 
     def setUp(self):
-        mock_pil_patch = mock.patch('PIL.Image.open')
+        mock_pil_patch = mock.patch('processor.resize.Image.open')
         self.addCleanup(mock_pil_patch.stop)
         self.mock_pil = mock_pil_patch.start()
 


### PR DESCRIPTION
Apparently you can't just import PIL and get the Image submodule:

https://stackoverflow.com/questions/11911480/python-pil-has-no-attribute-image